### PR TITLE
[finishes #164035726] enable editing of office even if a user provide…

### DIFF
--- a/app/api/v2/models/office_model.py
+++ b/app/api/v2/models/office_model.py
@@ -97,7 +97,12 @@ class PoliticalOffice(BaseModel):
             query += "name = '" + str(uname) + "'"
         if 'office_type' in request.json and request.json['office_type'].strip():
             utype = request.json['office_type'].strip().lower()
-            query += ",office_type = '" + str(office_type) + "'"
+            if 'name' in request.json and request.json['name'].strip():
+                query += ",office_type = '" + str(office_type) + "'"
+            else:
+                query += "office_type = '" + str(office_type) + "'"
+
+            
 
         query += " where office_id = {}".format(office_id)
         # import pdb; pdb.set_trace()


### PR DESCRIPTION
**What does this PR do?**
Fixes a bug whereby a user was not able to edit office data if he/she provided only one value.

**What are the tasks to be completed?**
-Change the format of the update query to check if the user provided all or a number of the parameters.

**How can this be manually tested**
Using the data in this [documentation](https://politico14.docs.apiary.io/)
- Create a user
- Login and copy the token
- Create an office while passing the token as the header
-Try editing the created office while passing only one property e.g. name only

**What are the relevant Pivotal Tracker Stories?**
[#164035726](https://www.pivotaltracker.com/n/projects/2241865)