### PR TITLE
[finishes #164035480] enable editing of a party when not provided wit…

### DIFF
--- a/app/api/v2/models/party_model.py
+++ b/app/api/v2/models/party_model.py
@@ -98,10 +98,16 @@ class PoliticalParty(BaseModel):
             query += "name = '" + str(uname) + "'"
         if 'hqAddress' in request.json and request.json['hqAddress'].strip():
             uhqAddress = request.json['hqAddress'].strip().lower()
-            query += ",hqAddress = '" + str(uhqAddress) + "'"
+            if 'name' in request.json and request.json['name'].strip():
+                query += ",hqAddress = '" + str(uhqAddress) + "'"
+            else:
+                query += "hqAddress = '" + str(uhqAddress) + "'"
         if 'logoUrl' in request.json and request.json['logoUrl'].strip():
             ulogoUrl = request.json['logoUrl'].strip().lower()
-            query += ",logoUrl = '" + str(ulogoUrl) + "'"
+            if 'hqAddress' in request.json and request.json['hqAddress'].strip() or 'name' in request.json and request.json['name'].strip():
+                query += ",logoUrl = '" + str(ulogoUrl) + "'"
+            else:
+                query += "logoUrl = '" + str(ulogoUrl) + "'"
 
         query += " where party_id = {}".format(party_id)
         # import pdb; pdb.set_trace()


### PR DESCRIPTION
**What does this PR do?**
Fixes a bug whereby a user was not able to edit party data if he/she did not provide all values

**What are the tasks to be completed?**
-Change the format of the update query to check if the user provided all or a number of the parameters.

**How can this be manually tested**
Using the data in this [documentation](https://politico14.docs.apiary.io/)
- Create a user
- Login and copy the token
- Create a party while passing the token as the header
-Try editing the created party while passing only one or a number of properties but not all e.g. name only

**What are the relevant Pivotal Tracker Stories?**
[#164035480](https://www.pivotaltracker.com/n/projects/2241865)